### PR TITLE
Drop support for datafs < 0.6.8

### DIFF
--- a/impactlab_user/__init__.py
+++ b/impactlab_user/__init__.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import
 
 __author__ = """Climate Impact Lab"""
 __email__ = 'jsimcock@rhg.com'
-__version__ = '0.1.4'
+__version__ = '0.1.5'
 
 _module_imports = (
 )

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.4
+current_version = 0.1.5
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ entry_points = '[console_scripts]\nimpactlab-user=impactlab_user.cli:cli'
 
 setup(
     name='impactlab_user',
-    version='0.1.4',
+    version='0.1.5',
     description="Set up users to use Climate Impact Lab tools",
     long_description=readme,
     author="Climate Impact Lab",

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ requirements_install = [
     'sphinx_rtd_theme>=0.1.0',
     'boto>=2.30.0',
     'boto3>=1.0',
-    'datafs>=0.6.3',
+    'datafs>=0.6.8',
     'jinja2>=2.8'
     ]
 
@@ -24,7 +24,7 @@ requirements_test = [
     'sphinx_rtd_theme>=0.1.0',
     'boto>=2.30.0',
     'boto3>=1.0',
-    'datafs>=0.6.3',
+    'datafs>=0.6.8',
     'jinja2>=2.8',
     'pip>=8.0',
     'wheel>=0.27',


### PR DESCRIPTION
Datafs 0.6.7 introduced significant API changes, but also introduced a deployment bug that was fixed in 0.6.8. This version drops support for all previous versions.